### PR TITLE
index: use webmodules for Range/Selection stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,11 @@
   "homepage": "https://github.com/webmodules/dom-paste",
   "devDependencies": {
     "typescript": "~1.0.1"
+  },
+  "dependencies": {
+    "current-range": "~1.1.0",
+    "current-selection": "~1.1.0",
+    "selection-is-backward": "~1.0.0",
+    "selection-set-range": "~1.0.0"
   }
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,19 @@
+declare module "current-range" {
+  function currentRange(doc: any): Range;
+  export = currentRange;
+}
+
+declare module "current-selection" {
+  function currentSelection(doc: any): Selection;
+  export = currentSelection;
+}
+
+declare module "selection-is-backward" {
+  function isBackward(selection: Selection): boolean;
+  export = isBackward;
+}
+
+declare module "selection-set-range" {
+  function setRange(selection: Selection, range: Range, backwards?: boolean): void;
+  export = setRange;
+}


### PR DESCRIPTION
Using "selection-set-range", "selection-is-backward", "current-range", and "current-selection" modules to maintain "backwards" selection and DRY up the code a little bit.
