### PR TITLE
index: use `position: fixed` to prevent the page from jumping

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,8 +30,13 @@ function domPaste(e: Event, callback: (data: HTMLElement) => void) {
   // create temporary content editable contaner
   var container: HTMLElement = doc.createElement('div');
   container.contentEditable = 'true';
+  container.style.position = 'fixed';
+  container.style.overflow = 'hidden';
+  container.style.width = container.style.height = container.style.top = container.style.left = '0px';
+
   var br: HTMLElement = doc.createElement('br'); // needed by Firefox
   container.appendChild(br);
+
   doc.body.appendChild(container);
 
   // observer for dom mutations in container


### PR DESCRIPTION
Before, when you invoked `dom-paste`, the browser would scroll
to the bottom of the page, since that's where the new
"contenteditable" DIV was getting inserted.

Using `position: fixed` ensures that the DIV is on-screen,
as well as some additonal CSS to ensure that it's completely hidden.
