### PR TITLE
use setTimeout rather than MutationObserver

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ function domPaste(e: Event, callback: (data: HTMLElement) => void) {
   var backward: boolean = isBackward(selection);
   var range: Range = currentRange(selection);
   var activeElement = <HTMLElement>doc.activeElement;
-  
+
   // create temporary content editable contaner
   var container: HTMLElement = doc.createElement('div');
   container.contentEditable = 'true';
@@ -36,8 +36,7 @@ function domPaste(e: Event, callback: (data: HTMLElement) => void) {
 
   doc.body.appendChild(container);
 
-  // observer for dom mutations in container
-  var observer = new MutationObserver(function() {
+  setTimeout(function() {
     // remove br element, if it's still there (Firefox fix)
     if (br.parentNode) {
       br.parentNode.removeChild(br);
@@ -49,23 +48,12 @@ function domPaste(e: Event, callback: (data: HTMLElement) => void) {
       setRange(selection, range, backward);
     }
 
-    // avoid having handler fire again if changes
-    // are made within the callback
-    observer.disconnect();
-
     try {
       callback(container);
     } finally {
       // remove temporary container
       doc.body.removeChild(container);
     }
-  });
-
-  observer.observe(container, {
-    childList: true,
-    attributes: true,
-    characterData: true,
-    subtree: true
   });
 
   // move focus and selection to temporary container


### PR DESCRIPTION
MutationObserver may fire multiple times for very large pastes.  For example, if you go to this page

http://www.2ality.com/2015/02/es6-classes-final.html

Press ctrl+a, ctrl+c and then paste into here:

http://requirebin.com/?gist=TooTallNate/789b7e9cefb8be3f8254

You will see that the domPaste callback is called multiple times, whereas only one paste event is fired.

@TooTallNate 

EDIT: I should point out i've only tested this in Chrome.  Not sure about other browsers.

EDIT2: Firefox does not seem to have the issue.  Safari just plain chokes if you try to do such a crazy paste, so it may or may not have the issue with a paste of some intermediate level of insanity.

EDIT3: The issue appears to be connected to the presence of `<iframe>`'s in the paste.  If you remove the iframe's from that page, the issue disappears - though it doesn't seem to get one additional event for each frame, so it's unclear to me exactly what is happening.
